### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.13"
 edition = "2021"
 authors = ["Gabrielle Guimarães de Oliveira"]
 documentation = "https://github.com/aripiprazole/bupropion"
+repository = "https://github.com/aripiprazole/bupropion"
 license = "MIT"
 keywords = ["incremental", "parsing", "asena"]
 categories = ["parsing", "text-editors"]


### PR DESCRIPTION
to allow crates.io, rust-digger, and other to link to it